### PR TITLE
Dynamically detect the ValaC version. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-VALAC_VERSION = 0.32
+VALAC_VERSION = $(shell vala --version | awk -F. '{ print "0."$$2 }')
 PREFIX = "stable"
 
 gee-version = 0.18.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VALAC_VERSION = $(shell vala --version | awk -F. '{ print "0."$$2 }')
+VALAC_VERSION := $(shell vala --version | awk -F. '{ print "0."$$2 }')
 PREFIX = "stable"
 
 gee-version = 0.18.0


### PR DESCRIPTION
- Re-push of flobrosch/valadoc-org#63
- Works for any 0.x.x version.
- Builds to `valadoc-$version`