### PR TITLE
Fix search from index.htm

### DIFF
--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -19,7 +19,7 @@ var content_data = null
 var RESULTS_BULK = 20
 
 function clean_path () {
-  return window.location.pathname.replace(/(.html|.htm)/, '')
+  return window.location.pathname.replace(/(index)?(.html|.htm)/, '')
 }
 
 function check_loaded (path) {


### PR DESCRIPTION
When requesting from `search.php`, we pass a `curpkg` field which is taken from `clean_path()`