### PR TITLE
Upgrade version of libgee to 0.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VALAC_VERSION := $(shell vala --version | awk -F. '{ print "0."$$2 }')
 PREFIX = "stable"
 
-gee-version = 0.18.0
+gee-version = 0.18.1
 gee-pc-version = 0.8
 
 


### PR DESCRIPTION
This should fix the errors from Vala about incompatible types when building
the documentation. See issue #45 