### PR TITLE
ignore vapi-images in addition to gir-images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /configgen
 /documentation/*/gallery-images/*
 /documentation/*/gir-images/*
+/documentation/*/vapi-images/*
 /documentation/*/index.sgml
 /documentation/*/widget-gallery.valadoc
 /documentation/*/wiki


### PR DESCRIPTION
This means git doesn't think `documentation/granite` has untracked files