### PR TITLE
don't show descriptions in search results

### DIFF
--- a/data/search.php
+++ b/data/search.php
@@ -68,7 +68,7 @@ if ($curpkg != '') {
 
 $query = $mysqli->real_escape_string ($query);
 
-$qq = "SELECT type, name, shortdesc, path, signature, type, typeorder,
+$qq = "SELECT type, name, path, signature, type, typeorder,
        {$orderby}
        FROM {$allpkgs}
        WHERE MATCH('{$query}')
@@ -85,9 +85,6 @@ while ($row = $q->fetch_assoc()) {
 
   echo '<li class="search-result '.$class.'"><a href="'.$row["path"].'">';
   echo '<span class="search-name">'.$row["name"].' <span class="search-package">('.$pkg.')</span></span>';
-  if (trim($row["shortdesc"]) != "") {
-    echo '<span class="search-desc">'.strip_tags($row["shortdesc"]).'</span>';
-  }
   echo '</a></li>';
 }
 

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -198,14 +198,13 @@ nav .title {
 
 .search-result a .search-package {
     display: inline;
-    font-style: italic;
+    font-size: 10px;
+    margin-left: 6px;
+    opacity: 0.8;
 }
 
 .search-result a .search-desc {
-    display: block;
-    font-size: 10px;
-    opacity: 0.75;
-    padding-left: 22px;
+    display: none;
 }
 
 .search-selected {
@@ -242,7 +241,7 @@ nav .title {
 }
 
 #sidebar .navi_main li {
-    padding: 3px 6px;
+    padding: 6px;
 }
 
 .navi_inline li:before,

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -127,7 +127,7 @@ nav .title {
     position: fixed;
     top: 48px;
     width: 240px;
-    height: 100%;
+    height: calc(100% - 48px);
 }
 
 #sidebar a {
@@ -161,6 +161,14 @@ nav .title {
     list-style: none;
     margin: 0;
     padding: 0;
+}
+
+#sidebar .site_navigation > ul:first-of-type {
+    margin-top: 7px;
+}
+
+#sidebar .site_navigation > ul:last-of-type {
+    margin-bottom: 7px;
 }
 
 #sidebar li {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -164,11 +164,11 @@ nav .title {
 }
 
 #sidebar .site_navigation > ul:first-of-type {
-    margin-top: 7px;
+    margin-top: 6px;
 }
 
 #sidebar .site_navigation > ul:last-of-type {
-    margin-bottom: 7px;
+    margin-bottom: 6px;
 }
 
 #sidebar li {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -164,7 +164,7 @@ nav .title {
 #sidebar ul {
     font-size: 12px;
     list-style: none;
-    margin: 6px 0;
+    margin: 0;
     padding: 0;
 }
 


### PR DESCRIPTION
It seems like the description here is pretty useless since you can't read the whole thing and some results don't even have one and it shows in the tooltip anyways.

If we remove it we can actually make the individual result items larger, which I think makes them easier to read and still save vertical space.

Should look like this:

![screenshot from 2017-02-22 18 32 07](https://cloud.githubusercontent.com/assets/7277719/23242507/f2f4626a-f92d-11e6-90ba-a67ac68fa57d.png)
