### PR TITLE
HTML5 improvements

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -59,7 +59,7 @@ if ($first == null || $first === "index") { // Homepage
   <meta property="og:title" content="<?php echo get_title ($page); ?>">
   <meta property="og:type" content="website">
   <title><?php echo get_title ($page); ?></title>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Droid+Serif:400|Roboto+Mono:400,500,700,400italic">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400%7CDroid+Serif:400%7CRoboto+Mono:400,500,700,400italic">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="/styles/main.css" type="text/css">
   <link rel="apple-touch-icon" href="/images/icon.png" />

--- a/data/index.php
+++ b/data/index.php
@@ -47,7 +47,7 @@ if ($first == null || $first === "index") { // Homepage
 
 ?>
 <!doctype html>
-<html lang="en">
+<html lang="en" itemscope itemtype="http://schema.org/WebSite">
 <head>
   <meta charset="UTF-8">
   <meta itemprop="image" content="https://valadoc.org/images/preview.png">

--- a/data/index.php
+++ b/data/index.php
@@ -68,7 +68,8 @@ if ($first == null || $first === "index") { // Homepage
 <body>
   <nav>
     <div id="search-box">
-      <input id="search-field" type="text" placeholder="Search" autocompletion="off" autosave="search" /><img id="search-field-clear" src="/images/clean.svg" />
+      <input id="search-field" type="search" placeholder="Search" autocomplete="off" />
+      <img id="search-field-clear" src="/images/clean.svg" alt="Clear search" />
     </div>
     <a class="title" href="/index.htm"><img alt="Valadoc" src="/images/logo.svg"/></a>
     <ul>

--- a/data/index.php
+++ b/data/index.php
@@ -88,7 +88,6 @@ if ($first == null || $first === "index") { // Homepage
     <div id="content">
       <?php @readfile (__DIR__ . "/" . $page . ".content.tpl"); ?>
     </div>
-    <div id="comments" />
   </div>
   <footer>
     Copyright © <?php echo date('Y'); ?> Valadoc.org | Documentation is licensed under the same terms as its upstream |

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -407,10 +407,6 @@ nav .title img {
     height: 52px;
 }
 
-#comments {
-    margin: 12px;
-}
-
 .tooltip {
     background-color: rgba(250, 250, 250, 0.95);
     border-radius: 3px;

--- a/src/doclet.vala
+++ b/src/doclet.vala
@@ -164,7 +164,7 @@ public class Valadoc.ValadocOrgDoclet : Valadoc.Html.BasicDoclet {
 		string basic_path = Path.build_filename(contentp, page.name.substring (0, page.name.length-7).replace ("/", ".")+"htm");
 
 		GLib.FileStream file = GLib.FileStream.open (basic_path + ".content.tpl", "w");
-		writer = new Html.MarkupWriter (file);
+		writer = new Html.MarkupWriter (file, false);
 		_renderer.set_writer (writer);
 
 		_renderer.set_container (page);
@@ -220,12 +220,12 @@ public class Valadoc.ValadocOrgDoclet : Valadoc.Html.BasicDoclet {
 		register_package_start (package, index_path);
 
 		GLib.FileStream file = GLib.FileStream.open (index_path + ".navi.tpl", "w");
-		writer = new Html.MarkupWriter (file);
+		writer = new Html.MarkupWriter (file, false);
 		_renderer.set_writer (writer);
 		write_navi_package (package);
 
 		file = GLib.FileStream.open (index_path + ".content.tpl", "w");
-		writer = new Html.MarkupWriter (file);
+		writer = new Html.MarkupWriter (file, false);
 		_renderer.set_writer (writer);
 		write_package_content (package, package);
 
@@ -242,12 +242,12 @@ public class Valadoc.ValadocOrgDoclet : Valadoc.Html.BasicDoclet {
 			register_node (ns);
 
 			GLib.FileStream file = GLib.FileStream.open (rpath + ".navi.tpl", "w");
-			writer = new Html.MarkupWriter (file);
+			writer = new Html.MarkupWriter (file, false);
 			_renderer.set_writer (writer);
 			write_navi_symbol (ns);
 
 			file = GLib.FileStream.open (rpath + ".content.tpl", "w");
-			writer = new Html.MarkupWriter (file);
+			writer = new Html.MarkupWriter (file, false);
 			_renderer.set_writer (writer);
 			write_namespace_content (ns, ns);
 		}
@@ -261,7 +261,7 @@ public class Valadoc.ValadocOrgDoclet : Valadoc.Html.BasicDoclet {
 
 
 		GLib.FileStream file = GLib.FileStream.open (rpath + ".navi.tpl", "w");
-		writer = new Html.MarkupWriter (file);
+		writer = new Html.MarkupWriter (file, false);
 		_renderer.set_writer (writer);
 
 		if (is_internal_node (node)) {
@@ -272,7 +272,7 @@ public class Valadoc.ValadocOrgDoclet : Valadoc.Html.BasicDoclet {
 
 
 		file = GLib.FileStream.open (rpath + ".content.tpl", "w");
-		writer = new Html.MarkupWriter (file);
+		writer = new Html.MarkupWriter (file, false);
 		_renderer.set_writer (writer);
 		write_symbol_content (node);
 

--- a/src/generator.vala
+++ b/src/generator.vala
@@ -566,7 +566,7 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 			writer.start_tag ("a", {"class", "video", "href", "https://www.youtube.com/watch?v=vxvZGf69nko", "target", "_blank"}).text ("Creating elementary OS apps with GTK & Vala").end_tag ("a");
 			writer.end_tag ("p");
 
-			writer.simple_tag ("hr/");
+			writer.simple_tag ("hr");
 			writer.start_tag ("h1").text ("Packages").end_tag ("h1");
 
 			writer.start_tag ("h2").text ("Submitting API-Bugs and Patches").end_tag ("h2");

--- a/src/generator.vala
+++ b/src/generator.vala
@@ -500,7 +500,7 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 
 	private void generate_navigation (string path) {
 		GLib.FileStream file = GLib.FileStream.open (path, "w");
-		var writer = new Html.MarkupWriter (file);
+		var writer = new Html.MarkupWriter (file, false);
 
 		writer.start_tag ("div", {"class", "site_navigation"});
 		writer.start_tag ("ul");
@@ -529,7 +529,7 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 
 		public override void render (string path, Collection<Node> sections) {
 			GLib.FileStream file = GLib.FileStream.open (path, "w");
-			writer = new Html.MarkupWriter (file);
+			writer = new Html.MarkupWriter (file, false);
 
 			// Intro:
 			writer.start_tag ("h1").text ("Guides & References").end_tag ("h1");

--- a/src/generator.vala
+++ b/src/generator.vala
@@ -626,7 +626,7 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 			}
 
 			if (pkg is ExternalPackage) {
-				writer.simple_tag ("img", {"src", "/images/external_link.svg"});
+				writer.simple_tag ("img", {"src", "/images/external_link.svg", "alt", "This valadoc is on another site"});
 			}
 
 			writer.start_tag ("div", {"class", "links"});


### PR DESCRIPTION
Getting rid of the xml header was done with the constructor argument: https://github.com/GNOME/vala/blob/bb5a612a7b22b14ac213f75bc5bf97f107a82636/libvaladoc/html/htmlmarkupwriter.vala#L28