### PR TITLE
Move tooltip 2 pixels away from click area

### DIFF
--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -42,8 +42,8 @@ function tooltip (element, content) {
 
   element.addEventListener('mousemove', evt => {
     tip.style.display = 'block'
-    tip.style.top = `${window.scrollY + evt.clientY}px`
-    tip.style.left = `${window.scrollX + evt.clientX}px`
+    tip.style.top = `${window.scrollY + evt.clientY + 2}px`
+    tip.style.left = `${window.scrollX + evt.clientX + 2}px`
   })
 
   element.addEventListener('mouseleave', () => {


### PR DESCRIPTION
This avoids the tooltip being under the cursor and blocking click actions.