### PR TITLE
fix firefox loop bug

### DIFF
--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -70,7 +70,7 @@ function setupLink (link) {
       fetch(`/tooltip.php?fullname=${encodeURIComponent(fullname)}`, {
         method: 'POST'
       }).then(res => res.text()).then(res => {
-        for (const tip of html.tooltips) {
+        for (let tip of html.tooltips) {
           tip.style.display = 'none'
         }
 


### PR DESCRIPTION
Acording to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) there is a [bug with firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1101653) that makes the `const` value throw an error `missing = in const declaration`. Simple fix.