### PR TITLE
Fix a critical error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VALAC = valac
 VALAC_VERSION := $(shell vala --api-version | awk -F. '{ print "0."$$2 }')
-VALAFLAGS = -X -w
+VALAFLAGS = -g -X -w
 PREFIX = "stable"
 
 default: generator libdoclet.so update-girs configgen valadoc-example-gen valadoc-example-tester

--- a/src/generator.vala
+++ b/src/generator.vala
@@ -1296,11 +1296,6 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 			return -1;
 		}
 
-		if (FileUtils.test (metadata_path, FileTest.IS_REGULAR)) {
-			stdout.printf ("error: %s does not exist.\n", metadata_path);
-			return -1;
-		}
-
 		if (FileUtils.test ("tmp", FileTest.IS_DIR)) {
 			stdout.printf ("error: tmp already exist.\n");
 			return -1;
@@ -1320,9 +1315,7 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 			return -1;
 		}
 
-		if (metadata_path == null) {
-			metadata_path = "documentation/packages.xml";
-		}
+		metadata_path = "documentation/packages.xml";
 
 		if (docletpath == null) {
 			docletpath = ".";


### PR DESCRIPTION
metadata_path is not an argument we can set, so it will always be null when we check to see if it's a file

fixes `(generator:27479): GLib-CRITICAL **: g_file_test: assertion 'filename != NULL' failed`