### PR TITLE
Fix router path for all php versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,6 @@ test-examples: valadoc-example-tester
 
 
 serve: build-docs build-data
-	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org router.php
+	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org $(PWD)/valadoc.org/router.php
 serve-mini: build-docs-mini build-data
-	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org router.php
+	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org $(PWD)/valadoc.org/router.php


### PR DESCRIPTION
As of commit https://github.com/php/php-src/commit/816758eda2bcdd69ba505fb6bbb79124a7bf2254 PHP looks for the router in the docroot. Older versions of PHP don't do this