### PR TITLE
Fix #145: URL for external search (for valadoc DuckDuckGo !bang support)

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -67,7 +67,9 @@ if ($first == null || $first === "index") { // Homepage
 </head>
 <body>
   <nav>
-    <div id="search-box">
+    <div id="search-box" itemscope itemprop="potentialAction" itemtype="http://schema.org/SearchAction">
+      <meta itemprop="target" content="/?q={query}">
+      <meta itemprop="query-input" content="required name=query">
       <input id="search-field" type="search" placeholder="Search" autocomplete="off" />
       <img id="search-field-clear" src="/images/clean.svg" alt="Clear search" />
     </div>

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -234,9 +234,10 @@ document.addEventListener('DOMContentLoaded', () => {
     return urlParams
   }
   var urlParams = parseQueryString(location.search); 
-  html.searchField.value = urlParams.q
-  updateSearch()
-  
+  if( typeof urlParams.q !== 'undefined' && urlParams.q ) {
+    html.searchField.value = urlParams.q
+    updateSearch()
+  }
 })
 
 let searchDelay

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -233,7 +233,7 @@ document.addEventListener('DOMContentLoaded', () => {
     )
     return urlParams
   }
-  const urlParams = parseQueryString(location.search); 
+  const urlParams = parseQueryString(location.search)
   if (typeof urlParams.q !== 'undefined' && urlParams.q) {
     html.searchField.value = urlParams.q
     updateSearch()

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -234,7 +234,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return urlParams
   }
   var urlParams = parseQueryString(location.search); 
-  if( typeof urlParams.q !== 'undefined' && urlParams.q ) {
+  if (typeof urlParams.q !== 'undefined' && urlParams.q) {
     html.searchField.value = urlParams.q
     updateSearch()
   }

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -221,6 +221,22 @@ document.addEventListener('DOMContentLoaded', () => {
         break
     }
   })
+
+  // Conduct a search if the "q" field is present in the URL Parameters
+  var parseQueryString = function(url) {
+    var urlParams = {}
+    url.replace(
+      new RegExp("([^?=&]+)(=([^&]*))?", "g"),
+      function($0, $1, $2, $3) {
+        urlParams[$1] = $3
+      }
+    )
+    return urlParams
+  }
+  var urlParams = parseQueryString(location.search); 
+  html.searchField.value = urlParams.q
+  updateSearch()
+  
 })
 
 let searchDelay

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -223,8 +223,8 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // Conduct a search if the "q" field is present in the URL Parameters
-  var parseQueryString = function(url) {
-    var urlParams = {}
+  function parseQueryString (url) {
+    let urlParams = {}
     url.replace(
       new RegExp("([^?=&]+)(=([^&]*))?", "g"),
       function($0, $1, $2, $3) {
@@ -233,7 +233,7 @@ document.addEventListener('DOMContentLoaded', () => {
     )
     return urlParams
   }
-  var urlParams = parseQueryString(location.search); 
+  const urlParams = parseQueryString(location.search); 
   if (typeof urlParams.q !== 'undefined' && urlParams.q) {
     html.searchField.value = urlParams.q
     updateSearch()


### PR DESCRIPTION
Fixes #145: URL for external search (for valadoc DuckDuckGo !bang support)

### What it does
- Parse URL [GET] Parameters
- Check for a "q" parameter
- Put it in the search box (UX)
- Trigger a search