### PR TITLE
Remove dead link

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -74,7 +74,6 @@ if ($first == null || $first === "index") { // Homepage
     <a class="title" href="/index.htm"><img alt="Valadoc" src="/images/logo.svg"/></a>
     <ul>
       <li><a href="https://plus.google.com/communities/113287185626826620884" target="_blank" title="Google+"><i class="fa fa-google-plus"></i></a>
-      <li><a href="http://stackoverflow.com/documentation/vala/" target="_blank" title="stackoverflow"><i class="fa fa-stack-overflow"></i></a>
       <li><a href="https://www.reddit.com/r/vala/" target="_blank" title="reddit"><i class="fa fa-reddit"></i></a>
       <li><a href="/markup.htm" title="Markup Info"><i class="fa fa-info-circle"></i></a>
     </ul>


### PR DESCRIPTION
The link to http://stackoverflow.com/documentation/vala/ should be removed because it is dead.

Fixes elementary/website#1878