### PR TITLE
Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,4 +29,3 @@
 !.babelrc
 !.editorconfig
 !.stylelintrc.json
-!.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,5 @@ COPY --from=build-assets /opt/valadoc/valadoc.org /var/www/html
 # A couple default apache changes to make valadoc work
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
 
-COPY docker-server.sh /usr/local/bin/valadoc
-CMD ["valadoc"]
+COPY docker-server.sh /usr/local/bin/valadoc.org
+CMD ["valadoc.org"]

--- a/Dockerfile-valadoc
+++ b/Dockerfile-valadoc
@@ -1,0 +1,53 @@
+# Dockerfile-valadoc
+## Builds valadoc and serves it with a basic PHP server
+
+# Build valadoc
+FROM ubuntu:18.04 as build-docs
+
+# Install basic needed packages
+RUN apt update && apt install -y --no-install-recommends software-properties-common
+
+# Install third party repos
+RUN add-apt-repository -y ppa:vala-team
+
+# Install valadoc and server packages
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install \
+  -y \
+  --no-install-recommends \
+  gcc \
+  gee-0.8 \
+  git \
+  libguestfs-gobject-1.0 \
+  libvaladoc-dev \
+  php \
+  php-curl \
+  unzip \
+  valac \
+  valadoc \
+  wget
+
+# Copy over the valadoc stuff
+COPY . /opt/valadoc
+WORKDIR /opt/valadoc
+
+# Build docs
+RUN make build-docs || true
+
+# Build valadoc assets
+FROM node:10 as build-assets
+
+# Copy over the valadoc stuff
+COPY --from=build-docs /opt/valadoc /opt/valadoc
+WORKDIR /opt/valadoc
+
+# Build website assets
+RUN make build-data
+
+# Cleanup and publish
+FROM php:apache
+
+# Cleanup to make the image smaller
+COPY --from=build-assets /opt/valadoc/valadoc.org/ /var/www/html/
+
+# A couple default apache changes to make valadoc work
+COPY apache.conf /etc/apache2/sites-available/000-default.conf

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ check-examples: valadoc-example-tester
 
 build-data:
 	npm install
-	./node_modules/.bin/gulp
+	npx gulp
 
 
 #

--- a/apache.conf
+++ b/apache.conf
@@ -1,0 +1,9 @@
+<VirtualHost *:80>
+	ServerAdmin hosting@elementary.io
+	DocumentRoot /var/www/html
+
+  FallbackResource /index.php
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/docker-server.sh
+++ b/docker-server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /opt/valadoc && searchd
+apache2-foreground


### PR DESCRIPTION
This PR adds a `Dockerfile` that will produce a 4.4 GB (currently) docker image that contains all of the docs, the search backend, and a php server.

You can build and run it with:
```
docker build -t valadoc .
docker run --rm -it -p 3000:80 valadoc
```

This will start valadoc listenable on port 3000.

**NOTE** While the finished image is about 4.4 GB, building it will take more room.