### PR TITLE
Use even GLib version to make latest Valac happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build-docs: default
 		--vapidir "extra-vapis/" --vapidir "girs/vala/vapi/" \
 		--driver $(VALAC_VERSION) \
 		--prefix $(PREFIX) \
-		--target-glib 2.99 \
+		--target-glib 2.98 \
 		--download-images \
 		--skip-existing \
 		--no-check-certificate \
@@ -119,7 +119,7 @@ build-docs-mini: default
 		--vapidir "extra-vapis/" --vapidir "girs/vala/vapi/" \
 		--driver $(VALAC_VERSION) \
 		--prefix $(PREFIX) \
-		--target-glib 2.99 \
+		--target-glib 2.98 \
 		--download-images \
 		--skip-existing \
 		--no-check-certificate \


### PR DESCRIPTION
Since https://gitlab.gnome.org/GNOME/vala/commit/3d926c1288b3ec4fd692dd1de6b91fb6c2090183 the minimum GLib version should be even