### PR TITLE
Replace libgsignon-glib with libsignon-glib

### DIFF
--- a/documentation/packages.xml
+++ b/documentation/packages.xml
@@ -402,7 +402,7 @@
 			<package name="gsignond" gir="gSignond-1.0" home="https://gitlab.com/accounts-sso/gsignond" c-docs="http://accounts-sso.gitlab.io/gsignond/">
 				Single signon daemon library.
 			</package>
-			<package name="libgsignon-glib" gir="gSignon-1.0" home="https://gitlab.com/accounts-sso/libgsignon-glib" c-docs="http://accounts-sso.gitlab.io/libgsignon-glib/">
+			<package name="libsignon-glib" gir="Signon-2.0" home="https://gitlab.com/accounts-sso/libsignon-glib" c-docs="http://accounts-sso.gitlab.io/libsignon-glib/">
 				Single signon authentication library for online services.
 			</package>
 			<package name="vsgi-0.3" home="https://github.com/valum-framework/valum">


### PR DESCRIPTION
libgsignon-glib has been deprecated in favor of libsignon-glib