### PR TITLE
Remove folks-libsocialweb

### DIFF
--- a/documentation/packages.xml
+++ b/documentation/packages.xml
@@ -350,9 +350,6 @@
 			<package name="folks-eds" home="https://wiki.gnome.org/Projects/Folks" maintainers="Travis Reitter" c-docs="http://telepathy.freedesktop.org/doc/folks/c/">
 				Folks, eds-backend
 			</package>
-			<package name="folks-libsocialweb" home="https://wiki.gnome.org/Projects/Folks" maintainers="Travis Reitter" c-docs="http://telepathy.freedesktop.org/doc/folks-libsocialweb/c/">
-				Folks, libsocialweb-backend
-			</package>
 			<package name="folks-telepathy" home="https://wiki.gnome.org/Projects/Folks" maintainers="Travis Reitter" c-docs="http://telepathy.freedesktop.org/doc/folks-telepathy/c/">
 				Folks, telepathy-backend
 			</package>


### PR DESCRIPTION
libsocialweb itself is dead and folks-libsocialweb isn't available in any major distribution since ages