### PR TITLE
Remove dbus-glib

### DIFF
--- a/documentation/packages.xml
+++ b/documentation/packages.xml
@@ -595,9 +595,6 @@ simple methods via GObject-Introspection
 				AppStream is a cross-distro effort for enhancing the way we interact with the software
 				repositories provided by the distribution by standardizing sets of additional metadata.
 			</package>
-			<package name="dbus-glib-1" gir="DBusGLib-1.0" c-docs="https://developer.gnome.org/dbus-glib/unstable/">
-				D-Bus Support
-			</package>
 			<package name="jsonrpc-glib-1.0" gir="Jsonrpc-1.0">
 				Jsonrpc-GLib is a library to communicate with JSON-RPC based peers in either a synchronous or asynchronous fashion.
 				It also allows communicating using the GVariant serialization format instead of JSON when both peers support it.


### PR DESCRIPTION
Long deprecated and replaced by GDBus