### PR TITLE
GLib-2.0: be more specific in the documentation of float.MIN and double.MIN

### DIFF
--- a/documentation/glib-2.0/glib-2.0.valadoc
+++ b/documentation/glib-2.0/glib-2.0.valadoc
@@ -2141,7 +2141,7 @@ float.MAX_10_EXP
 float.EPSILON
 
 /**
- * Minimum value of float
+ * Minimum positive value of float, use -{@link float.MAX} to get the minimum negative value
  */
 float.MIN
 
@@ -2223,7 +2223,7 @@ double.MAX_10_EXP
 double.EPSILON
 
 /**
- * Minimum value of double
+ * Minimum positive value of double, use -{@link double.MAX} to get the minimum negative value
  */
 double.MIN
 


### PR DESCRIPTION
Possibly fixes https://gitlab.gnome.org/GNOME/vala/issues/680